### PR TITLE
【iOS】Optimize audience list implementation

### DIFF
--- a/iOS/Component/AudienceList/Sources/AudienceListView.swift
+++ b/iOS/Component/AudienceList/Sources/AudienceListView.swift
@@ -60,7 +60,6 @@ public class AudienceListView: RTCBaseView {
         service.state
     }
     private lazy var observer: AudienceListObserver = AudienceListObserver(state: state, service: service)
-    private lazy var audienceListPanel = AudienceListPanelView(state: state)
     private var listUser: [TUIUserInfo] = []
     private var cancellableSet: Set<AnyCancellable> = []
     private weak var popupViewController: UIViewController?
@@ -79,6 +78,7 @@ public class AudienceListView: RTCBaseView {
         collectionView.isUserInteractionEnabled = true
         collectionView.contentMode = .scaleToFill
         collectionView.dataSource = self
+        collectionView.isScrollEnabled = false
         collectionView.register(UserInfoCell.self, forCellWithReuseIdentifier: cellId)
         return collectionView
     }()
@@ -169,7 +169,6 @@ public class AudienceListView: RTCBaseView {
         let tap = UITapGestureRecognizer(target: self, action: #selector(containerTapAction))
         addGestureRecognizer(tap)
         isUserInteractionEnabled = true
-        audienceListPanel.onUserManageButtonClicked = onUserManageButtonClicked
     }
     
     deinit {
@@ -197,7 +196,7 @@ extension AudienceListView: UICollectionViewDataSource {
     }
 
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return listUser.count
+        return min(2, listUser.count)
     }
 
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -213,7 +212,10 @@ extension AudienceListView: UICollectionViewDataSource {
 
 extension AudienceListView {
     @objc func containerTapAction() {
+        service.getUserList()
         if let vc = WindowUtils.getCurrentWindowViewController() {
+            let audienceListPanel = AudienceListPanelView(state: state)
+            audienceListPanel.onUserManageButtonClicked = onUserManageButtonClicked
             popupViewController = vc
             let menuContainerView = MenuContainerView(contentView: audienceListPanel)
             audienceListPanel.onBackButtonClickedClosure = { [weak self] in

--- a/iOS/Component/AudienceList/Sources/Service/AudienceListObserver.swift
+++ b/iOS/Component/AudienceList/Sources/Service/AudienceListObserver.swift
@@ -11,7 +11,6 @@ import RTCRoomEngine
 class AudienceListObserver: NSObject, TUIRoomObserver {
     private let state: AudienceListState
     private weak var service: AudienceListService?
-    private var lastFetchDate: Date?
     
     init(state: AudienceListState, service: AudienceListService) {
         self.state = state
@@ -29,15 +28,6 @@ class AudienceListObserver: NSObject, TUIRoomObserver {
         guard !state.audienceList.contains(where: { $0.userId == userInfo.userId }) else { return }
         if state.audienceList.count < kMaxShowUserCount {
             state.audienceList.append(userInfo)
-        } else {
-            let current = Date()
-            if let last = lastFetchDate {
-                if last.timeIntervalSince(current) < 10 {
-                    return
-                }
-            }
-            lastFetchDate = current
-            service?.getUserList()
         }
     }
     

--- a/iOS/Component/AudienceList/Sources/View/AudienceListPanelView.swift
+++ b/iOS/Component/AudienceList/Sources/View/AudienceListPanelView.swift
@@ -107,7 +107,7 @@ extension AudienceListPanelView {
         userListTableView.snp.remakeConstraints { make in
             make.leading.trailing.bottom.equalToSuperview()
             make.top.equalTo(backButton.snp.bottom).offset(32)
-            make.height.equalTo(593.scale375Height())
+            make.height.equalTo(screenHeight * 2 / 3)
         }
     }
 }


### PR DESCRIPTION
Key changes:

1. Removed audience list fetching logic triggered by user room entry
2. Implemented on-demand audience list retrieval when popup is opened
3. Fixed scroll behavior to prevent avatars on the count indicator from scrolling
4. Updated popup height to 2/3 of screen height for better visibility